### PR TITLE
remove unused proto import from validations.proto

### DIFF
--- a/fender/v1/validations.proto
+++ b/fender/v1/validations.proto
@@ -2,7 +2,6 @@ package fender.v1;
 
 option java_package = "com.fender.v1";
 
-import "google/protobuf/descriptor.proto";
 import "fender/v1/field_options.proto";
 
 enum ValidationErrorType {


### PR DESCRIPTION
Fix the following protoc warning

```
[libprotobuf WARNING google/protobuf/descriptor.cc:5411] Warning: Unused import: "fender/v1/validations.proto" imports "google/protobuf/descriptor.proto" which is not used.
```
